### PR TITLE
Fix classlist

### DIFF
--- a/src/d3/ClassList.js
+++ b/src/d3/ClassList.js
@@ -23,6 +23,10 @@ var ClassList = function (el) {
    * Initialize ClassList.
    */
   _initialize = function () {
+    _syncValue = null;
+    _classList = [];
+    _this.length = 0;
+
     _sync(true);
   };
 
@@ -35,19 +39,25 @@ var ClassList = function (el) {
    *        otherwise, set element state.
    */
   _sync = function (load) {
-    var value = ('' + el.getAttribute('class'));
-    if (_syncValue !== value) {
-      if (load) {
-        // read from element
+    var value;
+
+    if (load) {
+      // read from element
+      value = el.getAttribute('class');
+      if (value === null) {
+        _classList = [];
+        _this.length = 0;
+      } else {
+        value = '' + value;
         _classList = value.split(' ');
         _this.length = _classList.length;
-      } else {
-        // update element
-        value = _classList.join(' ');
-        el.setAttribute('class', value);
       }
-      _syncValue = value;
+    } else {
+      // update element
+      value = _classList.join(' ');
+      el.setAttribute('class', value);
     }
+    _syncValue = value;
   };
 
   /**

--- a/src/d3/D3LineView.js
+++ b/src/d3/D3LineView.js
@@ -211,6 +211,7 @@ var D3LineView = function (options) {
     var point;
 
     point = d3.event.target;
+    ClassList.polyfill(point);
     point.classList.remove('mouseover');
 
     // clear previous tooltip
@@ -227,6 +228,7 @@ var D3LineView = function (options) {
     var point;
 
     point = d3.event.target;
+    ClassList.polyfill(point);
     point.classList.add('mouseover');
 
     _this.view.showTooltip(coords, [


### PR DESCRIPTION
This pull request fixes usgs/earthquake-hazard-tool#80. Alternatively we could consider using a broadly adopted polyfill:

https://github.com/eligrey/classList.js