### PR TITLE
Ie responsive fix

### DIFF
--- a/example/D3View.html
+++ b/example/D3View.html
@@ -16,6 +16,9 @@
   <h2>D3View Example</h2>
   <div id="example">Example goes here.</div>
 
+  <h3>Other content</h3>
+  <p>This content exists to show how content flows around D3View.</p>
+
   <script src="hazdev-d3.js"></script>
   <script src="D3View.js"></script>
 </body>

--- a/src/d3/D3View.js
+++ b/src/d3/D3View.js
@@ -154,8 +154,9 @@ var D3View = function (options) {
     }, options), {silent: true});
 
     el = _this.el;
+    el.classList.add('D3View');
     el.innerHTML =
-          '<svg xmlns="http://www.w3.org/2000/svg" class="D3View">' +
+          '<svg xmlns="http://www.w3.org/2000/svg">' +
             '<defs>' +
               '<clipPath id="plotAreaClip">' +
                 '<rect x="0" y="0"></rect>' +
@@ -413,10 +414,9 @@ var D3View = function (options) {
       innerWidth = outerWidth - paddingLeft - paddingRight;
       innerHeight = outerHeight - paddingTop - paddingBottom;
       // update elements
+      _this.el.style.paddingBottom = (100 * height / width) + '%';
       _svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
       _svg.setAttribute('preserveAspectRatio', 'xMinYMin meet');
-      _svg.setAttribute('height', height);
-      _svg.setAttribute('width', '100%');
       _plotAreaClip.setAttribute('width', innerWidth);
       _plotAreaClip.setAttribute('height', innerHeight);
       _margin.setAttribute('transform',

--- a/src/d3/_D3View.scss
+++ b/src/d3/_D3View.scss
@@ -3,7 +3,7 @@
   height: 0;
   overflow: hidden;
   /**
-    padding-bottom is set by D3View class.
+    padding-bottom is set to `(100 * height / width)%` by the D3View class.
     This preserves aspect ratio, but allows plots to be responsive in IE.
    */
   position: relative;

--- a/src/d3/_D3View.scss
+++ b/src/d3/_D3View.scss
@@ -1,6 +1,7 @@
 
 .D3View {
   height: 0;
+  overflow: hidden;
   /**
     padding-bottom is set by D3View class.
     This preserves aspect ratio, but allows plots to be responsive in IE.

--- a/src/d3/_D3View.scss
+++ b/src/d3/_D3View.scss
@@ -1,8 +1,22 @@
 
 .D3View {
-  fill: none;
-  stroke: none;
-  stroke-width: 0;
+  height: 0;
+  /**
+    padding-bottom is set by D3View class.
+    This preserves aspect ratio, but allows plots to be responsive in IE.
+   */
+  position: relative;
+  width: 100%;
+
+  > svg {
+    fill: none;
+    left: 0;
+    position: absolute;
+    stroke: none;
+    stroke-width: 0;
+    top: 0;
+    width: 100%;
+  }
 
   /* text */
   .axis {


### PR DESCRIPTION
This appears to render consistently in IE and other browsers.  Note that the `D3View` class moved from the `svg` element to the view element, not sure if external classes depend on this?

Also, now that the view container is used for layout it cannot also be a column (which affects at least earthquake-hazard-tool).